### PR TITLE
Remove encryption requirements from crosshair

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,9 +11,7 @@ crosshair_gunicorn_loglevel: info
 crosshair_gunicorn_log: /var/log/crosshair.log
 crosshair_celery_log: /var/log/celery.log
 crosshair_settings_file: crosshair.settings_production
-crosshair_encryption_key: ""
 crosshair_database_local: no
 crosshair_database_host: ""
 crosshair_database_password: ""
-crosshair_database_password_unencrypted: ""
 crosshair_secret_key: ""

--- a/tasks/postgres.yml
+++ b/tasks/postgres.yml
@@ -22,6 +22,6 @@
   sudo_user: postgres
   postgresql_user: db=crosshair
                    name=crosshair
-                   password={{ crosshair_database_password_unencrypted }}
+                   password={{ crosshair_database_password }}
                    priv=ALL
                    state=present

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,6 @@
 ---
 crosshair_environment:
   DJANGO_SETTINGS_MODULE: "{{ crosshair_settings_file }}"
-  CROSSHAIR_ENCRYPTION_KEY: "{{ crosshair_encryption_key }}"
   CROSSHAIR_DATABASE_HOST: "{{ crosshair_database_host }}"
   CROSSHAIR_DATABASE_PASSWORD: "{{ crosshair_database_password }}"
   CROSSHAIR_SECRET_KEY: "{{ crosshair_secret_key }}"


### PR DESCRIPTION
Previously crosshair relied on an encryption key for storing local credentials. No longer the case.
