### PR TITLE
Remove gunicorn group from starting gunicorn

### DIFF
--- a/templates/gunicorn_start.j2
+++ b/templates/gunicorn_start.j2
@@ -11,7 +11,6 @@ exec gunicorn \
     --workers {{ crosshair_gunicorn_workers }} \
     --timeout {{ crosshair_gunicorn_timeout }} \
     --user gunicorn \
-    --group gunicorn \
     --log-level {{ crosshair_gunicorn_loglevel }} \
     --bind 127.0.0.1:{{ crosshair_gunicorn_port }} \
     crosshair.wsgi


### PR DESCRIPTION
Causes permission issues and to be honest not sure why we should specify this
